### PR TITLE
[PAGOPA-2263] fix: resolved impossibility to handle large flows 

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-chart
 description: Flussi di rendicontazioni
 type: application
-version: "1.24.0"
-appVersion: "1.0.20-1-PAGOPA-1976"
+version: "1.25.0"
+appVersion: "1.0.20-2-PAGOPA-1976"
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-chart
 description: Flussi di rendicontazioni
 type: application
-version: "1.23.0"
-appVersion: "1.0.20"
+version: "1.24.0"
+appVersion: "1.0.20-1-PAGOPA-1976"
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-chart
 description: Flussi di rendicontazioni
 type: application
-version: "1.25.0"
-appVersion: "1.0.20-2-PAGOPA-1976"
+version: "1.26.0"
+appVersion: "1.0.20-3-PAGOPA-1976"
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: pagopa-fdr-chart
 description: Flussi di rendicontazioni
 type: application
-version: "1.26.0"
-appVersion: "1.0.20-3-PAGOPA-1976"
+version: "1.27.0"
+appVersion: "1.0.20-4-PAGOPA-1976"
 dependencies:
   - name: microservice-chart
     version: 3.0.0

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-fdr
-    tag: 1.0.20
+    tag: 1.0.20-1-PAGOPA-1976
     pullPolicy: Always
   readinessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-fdr
-    tag: 1.0.20-1-PAGOPA-1976
+    tag: 1.0.20-2-PAGOPA-1976
     pullPolicy: Always
   readinessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-fdr
-    tag: 1.0.20-2-PAGOPA-1976
+    tag: 1.0.20-3-PAGOPA-1976
     pullPolicy: Always
   readinessProbe:
     httpGet:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-fdr
-    tag: 1.0.20-3-PAGOPA-1976
+    tag: 1.0.20-4-PAGOPA-1976
     pullPolicy: Always
   readinessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-fdr
-    tag: 1.0.20
+    tag: 1.0.20-1-PAGOPA-1976
     pullPolicy: Always
   readinessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-fdr
-    tag: 1.0.20-1-PAGOPA-1976
+    tag: 1.0.20-2-PAGOPA-1976
     pullPolicy: Always
   readinessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-fdr
-    tag: 1.0.20-2-PAGOPA-1976
+    tag: 1.0.20-3-PAGOPA-1976
     pullPolicy: Always
   readinessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -4,7 +4,7 @@ microservice-chart:
   fullnameOverride: ""
   image:
     repository: ghcr.io/pagopa/pagopa-fdr
-    tag: 1.0.20-3-PAGOPA-1976
+    tag: 1.0.20-4-PAGOPA-1976
     pullPolicy: Always
   readinessProbe:
     httpGet:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -94,5 +94,11 @@ microservice-chart:
     create: true
     host: "weuuat.fdr.internal.uat.platform.pagopa.it"
     path: /pagopa-fdr-service(/|$)(.*)
+    # currently set ingress timeout to 5m, until async handling will be introduced
+    annotations:
+      nginx.ingress.kubernetes.io/proxy-connect-timeout: "300"
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "300"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "300"
+      nginx.ingress.kubernetes.io/send_timeout: "300"
   canaryDelivery:
     create: false

--- a/openapi/openapi_internal.json
+++ b/openapi/openapi_internal.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20"
+    "version": "1.0.20-1-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_internal.json
+++ b/openapi/openapi_internal.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-2-PAGOPA-1976"
+    "version": "1.0.20-3-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_internal.json
+++ b/openapi/openapi_internal.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-3-PAGOPA-1976"
+    "version": "1.0.20-4-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_internal.json
+++ b/openapi/openapi_internal.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-1-PAGOPA-1976"
+    "version": "1.0.20-2-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_organization.json
+++ b/openapi/openapi_organization.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20"
+    "version": "1.0.20-1-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_organization.json
+++ b/openapi/openapi_organization.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-2-PAGOPA-1976"
+    "version": "1.0.20-3-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_organization.json
+++ b/openapi/openapi_organization.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-3-PAGOPA-1976"
+    "version": "1.0.20-4-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_organization.json
+++ b/openapi/openapi_organization.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-1-PAGOPA-1976"
+    "version": "1.0.20-2-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_psp.json
+++ b/openapi/openapi_psp.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20"
+    "version": "1.0.20-1-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_psp.json
+++ b/openapi/openapi_psp.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-2-PAGOPA-1976"
+    "version": "1.0.20-3-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_psp.json
+++ b/openapi/openapi_psp.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-3-PAGOPA-1976"
+    "version": "1.0.20-4-PAGOPA-1976"
   },
   "servers": [
     {

--- a/openapi/openapi_psp.json
+++ b/openapi/openapi_psp.json
@@ -4,7 +4,7 @@
     "title": "FDR - Flussi di rendicontazione (local)",
     "description": "Manage FDR ( aka \"Flussi di Rendicontazione\" ) exchanged between PSP and EC",
     "termsOfService": "https://www.pagopa.gov.it/",
-    "version": "1.0.20-1-PAGOPA-1976"
+    "version": "1.0.20-2-PAGOPA-1976"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.gov.pagopa</groupId>
   <artifactId>pagopa-fdr</artifactId>
-  <version>1.0.20-3-PAGOPA-1976</version>
+  <version>1.0.20-4-PAGOPA-1976</version>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <lombok.version>1.18.26</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.gov.pagopa</groupId>
   <artifactId>pagopa-fdr</artifactId>
-  <version>1.0.20-1-PAGOPA-1976</version>
+  <version>1.0.20-2-PAGOPA-1976</version>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <lombok.version>1.18.26</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.gov.pagopa</groupId>
   <artifactId>pagopa-fdr</artifactId>
-  <version>1.0.20-2-PAGOPA-1976</version>
+  <version>1.0.20-3-PAGOPA-1976</version>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <lombok.version>1.18.26</lombok.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>it.gov.pagopa</groupId>
   <artifactId>pagopa-fdr</artifactId>
-  <version>1.0.20</version>
+  <version>1.0.20-1-PAGOPA-1976</version>
   <properties>
     <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <lombok.version>1.18.26</lombok.version>

--- a/src/main/java/it/gov/pagopa/fdr/service/psps/PspsService.java
+++ b/src/main/java/it/gov/pagopa/fdr/service/psps/PspsService.java
@@ -312,7 +312,6 @@ public class PspsService {
             .project(FdrPaymentInsertEntity.class)
             .list();
 
-    log.debugf("Persisting FdrPaymentPublishEntity");
     FdrPublishEntity fdrPublishEntity = mapper.toFdrPublishEntity(fdrEntity);
     Instant now = Instant.now();
     fdrPublishEntity.setUpdated(now);
@@ -323,12 +322,10 @@ public class PspsService {
     FdrPaymentPublishEntity.persistFdrPaymentPublishEntities(fdrPaymentPublishEntities);
 
     // salva su storage dello storico
-    log.debugf("Persisting json file for history revision");
     HistoryBlobBody body = historyService.saveJsonFile(fdrPublishEntity, fdrPaymentPublishEntities);
     fdrPublishEntity.setRefJson(body);
     fdrPublishEntity.persistEntity();
 
-    log.debugf("Save historical data on storage");
     historyService.saveOnStorage(fdrPublishEntity, fdrPaymentPublishEntities);
 
     log.debug("Delete FdrInsertEntity");

--- a/src/main/java/it/gov/pagopa/fdr/service/psps/PspsService.java
+++ b/src/main/java/it/gov/pagopa/fdr/service/psps/PspsService.java
@@ -312,6 +312,7 @@ public class PspsService {
             .project(FdrPaymentInsertEntity.class)
             .list();
 
+    log.debugf("Persisting FdrPaymentPublishEntity");
     FdrPublishEntity fdrPublishEntity = mapper.toFdrPublishEntity(fdrEntity);
     Instant now = Instant.now();
     fdrPublishEntity.setUpdated(now);
@@ -322,10 +323,12 @@ public class PspsService {
     FdrPaymentPublishEntity.persistFdrPaymentPublishEntities(fdrPaymentPublishEntities);
 
     // salva su storage dello storico
+    log.debugf("Persisting json file for history revision");
     HistoryBlobBody body = historyService.saveJsonFile(fdrPublishEntity, fdrPaymentPublishEntities);
     fdrPublishEntity.setRefJson(body);
     fdrPublishEntity.persistEntity();
 
+    log.debugf("Save historical data on storage");
     // historyService.saveOnStorage(fdrPublishEntity, fdrPaymentPublishEntities);
 
     log.debug("Delete FdrInsertEntity");

--- a/src/main/java/it/gov/pagopa/fdr/service/psps/PspsService.java
+++ b/src/main/java/it/gov/pagopa/fdr/service/psps/PspsService.java
@@ -326,7 +326,7 @@ public class PspsService {
     fdrPublishEntity.setRefJson(body);
     fdrPublishEntity.persistEntity();
 
-    historyService.saveOnStorage(fdrPublishEntity, fdrPaymentPublishEntities);
+    // historyService.saveOnStorage(fdrPublishEntity, fdrPaymentPublishEntities);
 
     log.debug("Delete FdrInsertEntity");
     fdrEntity.delete();

--- a/src/main/java/it/gov/pagopa/fdr/service/psps/PspsService.java
+++ b/src/main/java/it/gov/pagopa/fdr/service/psps/PspsService.java
@@ -329,7 +329,7 @@ public class PspsService {
     fdrPublishEntity.persistEntity();
 
     log.debugf("Save historical data on storage");
-    // historyService.saveOnStorage(fdrPublishEntity, fdrPaymentPublishEntities);
+    historyService.saveOnStorage(fdrPublishEntity, fdrPaymentPublishEntities);
 
     log.debug("Delete FdrInsertEntity");
     fdrEntity.delete();

--- a/src/main/resources/schema-json/fdr_history_schema_v1.json
+++ b/src/main/resources/schema-json/fdr_history_schema_v1.json
@@ -180,8 +180,7 @@
                     } 
                 }
             },
-            "minItems": 1,
-            "maxItems": 1000
+            "minItems": 1
         }
     }
 }


### PR DESCRIPTION
This PR contains a workaround made for UAT environment in order to permits a correct publishing of flows. During a test, a PSP was blocked by a strange error. The error was, in first instance, caused by a limit on maximum number of payments on flow history JSON that blocked historicization on flows with more than 1k payments. In second instance, a little workaround is made on Ingress in order to add more time on timeout limit: in fact, the short timeout (1 minute) caused the HTTP connection to be truncated and the PSP was not allowed to receive information about the operation success or failure. This workaround is related to [another fix made on infrastructure](https://github.com/pagopa/pagopa-infra/pull/2470) in order to add PSPs' APIs in `upload.uat.platform.pagopa.it` domain.  
This second fix will be temporary: when an asyncronous mode will be made, the values set on Helm files will be deleted. 

#### List of Changes
 - removed upper limit on payment number on `fdr_history_schema_v1` schema
 - explicitly added longer timeout on Ingress

#### Motivation and Context
This change is required in order to permit PSPs to correctly ends publish operations. 

#### How Has This Been Tested?
 - Tested in DEV environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
