### PR TITLE
fix: defining natural sort for published and unpublished flows

### DIFF
--- a/src/main/java/it/gov/pagopa/fdr/repository/FlowRepository.java
+++ b/src/main/java/it/gov/pagopa/fdr/repository/FlowRepository.java
@@ -112,7 +112,7 @@ public class FlowRepository extends Repository implements PanacheRepository<Flow
     String queryString = String.join(" and ", queryBuilder);
 
     Page page = Page.of(pageNumber - 1, pageSize);
-    Sort sort = getSort(SortField.of("id", Direction.Ascending));
+    Sort sort = getSort(SortField.of("name", Direction.Ascending));
 
     PanacheQuery<FlowEntity> resultPage =
         FlowEntity.findPageByQuery(queryString, sort, parameters).page(page);
@@ -160,7 +160,10 @@ public class FlowRepository extends Repository implements PanacheRepository<Flow
     String queryString = String.join(" and ", queryBuilder);
 
     Page page = Page.of(pageNumber - 1, pageSize);
-    Sort sort = getSort(SortField.of("id", Direction.Ascending));
+    Sort sort =
+        getSort(
+            SortField.of("name", Direction.Ascending),
+            SortField.of("revision", Direction.Ascending));
 
     PanacheQuery<FlowEntity> resultPage =
         FlowEntity.findPageByQuery(queryString, sort, parameters).page(page);
@@ -241,7 +244,7 @@ public class FlowRepository extends Repository implements PanacheRepository<Flow
     String queryString = String.join(" and ", queryBuilder);
 
     Page page = Page.of(pageNumber - 1, pageSize);
-    Sort sort = getSort(SortField.of("id", Direction.Ascending));
+    Sort sort = getSort(SortField.of("name", Direction.Ascending));
 
     PanacheQuery<FlowEntity> resultPage =
         FlowEntity.findPageByQuery(queryString, sort, parameters).page(page);


### PR DESCRIPTION
This PR contains an enhancement made on paginated queries. The changes provide a sort order for published and unpublished flows made on name and revision fields, in ascendent order. In this way, the flows with same name but with different revisions are clustered in contiguous pages.

#### List of Changes
 - Replacing ID sort with name (and eventually revision) sort

#### Motivation and Context
This change is required in order to better show flows in paginated requests 

#### How Has This Been Tested?
Tested on local environment pointing towards development environment 

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
