### PR TITLE
fix: resolving bug on automatic generation of endpoint-related information in OAS

### DIFF
--- a/src/main/java/it/gov/pagopa/fdr/util/openapi/OpenAPIGenerator.java
+++ b/src/main/java/it/gov/pagopa/fdr/util/openapi/OpenAPIGenerator.java
@@ -114,7 +114,7 @@ public class OpenAPIGenerator implements OASFilter {
 
   private static void extractTableMetadata(Operation operation) {
     try {
-      String[] operationIdMethodReference = operation.getOperationId().split("\\.");
+      String[] operationIdMethodReference = operation.getOperationId().split("_");
       if (operationIdMethodReference.length == 2) {
 
         Class<?> controllerClass =


### PR DESCRIPTION
This PR contains a little fix on OpenAPI Swagger autogeneration process. After a previous fix, on which the controller's tags were changed from point-based annotation (i.e. `controller.endpoint`) to underscore-based annotation (i.e. `controller_endpoint`), the generated Swagger cannot:
 - correctly open sections
 - anchor links to specific endpoints
 - generate endpoint metadata tables
 - and maybe much more

The problem is caused by a broken parsing operation, that provide to generate endpoint tag from point-based annotation instead of newly defined underscore-based annotation.  
With this fix, the parsing is updated according to the new annotation format.  

#### List of Changes
 - Changed RegEx for endpoint parsing on OAS autogeneration process

#### Motivation and Context
This fix is required in order to resolve a bug on OAS autogenerated documentation 

#### How Has This Been Tested?
 - Tested in local environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
