### PR TITLE
feat: [PAGOPA-2696] Generating search indexes on `payments` table

### DIFF
--- a/src/main/java/it/gov/pagopa/fdr/controller/middleware/filter/ResponseFilter.java
+++ b/src/main/java/it/gov/pagopa/fdr/controller/middleware/filter/ResponseFilter.java
@@ -125,14 +125,13 @@ public class ResponseFilter implements ContainerResponseFilter {
           logErrorResponse(
               requestMethod, requestPath, requestSubject, elapsed, errorResponse.get());
         } else {
+          String message = null;
+          if (responseContext.getEntity() != null) {
+            message = ((Throwable) responseContext.getEntity()).getMessage();
+          }
           log.infof(
               "RES --> %s [uri:%s] [subject:%s] [elapsed:%dms] [statusCode:%d] [description:%s]",
-              requestMethod,
-              requestPath,
-              requestSubject,
-              elapsed,
-              httpStatus,
-              ((Throwable) responseContext.getEntity()).getMessage());
+              requestMethod, requestPath, requestSubject, elapsed, httpStatus, message);
         }
       } else {
         log.infof(

--- a/src/main/resources/db/migration/liquibase/changelog/1.0.2/db.changelog-202504220000.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.0.2/db.changelog-202504220000.sql
@@ -1,0 +1,7 @@
+--liquibase formatted sql
+
+-- ## INDEXES ##
+--changeset liquibase:202504220000-01
+CREATE INDEX payment_by_iuv_idx ON fdr3.payment (iuv);
+--changeset liquibase:202504220000-02
+CREATE INDEX payment_by_iur_idx ON fdr3.payment (iur);

--- a/src/main/resources/db/migration/liquibase/changelog/1.0.2/db.changelog-202504220000.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.0.2/db.changelog-202504220000.sql
@@ -2,6 +2,6 @@
 
 -- ## INDEXES ##
 --changeset liquibase:202504220000-01
-CREATE INDEX payment_by_iuv_idx ON fdr3.payment (iuv);
+CREATE INDEX IF NOT EXISTS payment_by_iuv_idx ON fdr3.payment (iuv);
 --changeset liquibase:202504220000-02
-CREATE INDEX payment_by_iur_idx ON fdr3.payment (iur);
+CREATE INDEX IF NOT EXISTS payment_by_iur_idx ON fdr3.payment (iur);

--- a/src/main/resources/db/migration/liquibase/changelog/db.changelog-master-1.0.1.xml
+++ b/src/main/resources/db/migration/liquibase/changelog/db.changelog-master-1.0.1.xml
@@ -5,6 +5,8 @@
 
   <property name="version" value="1.0.1" global="false"/>
 
-  <include file="./1.0.1/db.changelog-202504081545.sql"/>
+  <include file="./db.changelog-master-1.0.0.xml"/>
+
+  <include file="./${version}/db.changelog-202504081545.sql" labels="${version}"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/migration/liquibase/changelog/db.changelog-master-1.0.2.xml
+++ b/src/main/resources/db/migration/liquibase/changelog/db.changelog-master-1.0.2.xml
@@ -5,6 +5,8 @@
 
   <property name="version" value="1.0.2" global="false"/>
 
-  <include file="./1.0.2/db.changelog-202504220000.sql"/>
+  <include file="./db.changelog-master-1.0.1.xml"/>
+
+  <include file="./${version}/db.changelog-202504220000.sql" labels="${version}"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/migration/liquibase/changelog/db.changelog-master-1.0.2.xml
+++ b/src/main/resources/db/migration/liquibase/changelog/db.changelog-master-1.0.2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+  http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+  <property name="version" value="1.0.2" global="false"/>
+
+  <include file="./1.0.2/db.changelog-202504220000.sql"/>
+
+</databaseChangeLog>


### PR DESCRIPTION
This PR contains the definition of new indexes on `payment` table. In order to execute some deep searches of flows by payments, it is needed to add new indexes on IUV and IUR fields. This avoid the search to be so much long when Technical Support's application invoke the search APIs on this application.

**Note:**
Applying this change via Liquibase apply can lead to a lock on entire `fdr3.payment` table. During applies on UAT environment, the changes required about 10 minutes in order to be applied on tables of 25GB size.

#### List of Changes
 - Defining indexes creation using Liquibase changelogs
 - Resolving bug on logging process on response filter class

#### Motivation and Context
This change is required in order to resolve long timed operation during search operation in `payment` table 

#### How Has This Been Tested?
 - Tested in DEV environment
 - Tested in UAT environment 

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
