### PR TITLE
fix: [PAGOPA-3475] Incrementing rate-limit thresholds

### DIFF
--- a/infra/policy/psp/v1/_base_policy_payments_add.xml.tpl
+++ b/infra/policy/psp/v1/_base_policy_payments_add.xml.tpl
@@ -3,8 +3,8 @@
         <base />
         <choose>
             <when condition="@(!((string)context.Request.Headers.GetValueOrDefault("X-Orginal-Host-For","")).Equals("api.prf.platform.pagopa.it") && !((string)context.Request.OriginalUrl.ToUri().Host).Equals("api.prf.platform.pagopa.it"))">
-            <rate-limit-by-key calls="600" renewal-period="60" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" remaining-calls-header-name="x-remaining-calls-per-min" />
-            <rate-limit-by-key calls="50" renewal-period="1" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" remaining-calls-header-name="x-remaining-calls-per-sec" />
+                <rate-limit-by-key calls="600" renewal-period="60" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" remaining-calls-header-name="x-remaining-calls-per-min" />
+                <rate-limit-by-key calls="50" renewal-period="1" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" remaining-calls-header-name="x-remaining-calls-per-sec" />
             </when>
         </choose>
     </inbound>

--- a/infra/policy/psp/v1/_base_policy_payments_add.xml.tpl
+++ b/infra/policy/psp/v1/_base_policy_payments_add.xml.tpl
@@ -3,11 +3,8 @@
         <base />
         <choose>
             <when condition="@(!((string)context.Request.Headers.GetValueOrDefault("X-Orginal-Host-For","")).Equals("api.prf.platform.pagopa.it") && !((string)context.Request.OriginalUrl.ToUri().Host).Equals("api.prf.platform.pagopa.it"))">
-            <rate-limit-by-key calls="300" renewal-period="60" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" />
-            <rate-limit-by-key calls="10"
-                               renewal-period="1"
-                               increment-condition="@(context.Response.StatusCode != 429)"
-                               counter-key="@(context.Subscription.Key)"/>
+            <rate-limit-by-key calls="600" renewal-period="60" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" remaining-calls-header-name="x-remaining-calls-per-min" />
+            <rate-limit-by-key calls="50" renewal-period="1" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" remaining-calls-header-name="x-remaining-calls-per-sec" />
             </when>
         </choose>
     </inbound>

--- a/infra/policy/psp/v1/_base_policy_payments_delete.xml.tpl
+++ b/infra/policy/psp/v1/_base_policy_payments_delete.xml.tpl
@@ -3,11 +3,8 @@
         <base />
         <choose>
             <when condition="@(!((string)context.Request.Headers.GetValueOrDefault("X-Orginal-Host-For","")).Equals("api.prf.platform.pagopa.it") && !((string)context.Request.OriginalUrl.ToUri().Host).Equals("api.prf.platform.pagopa.it"))">
-                <rate-limit-by-key calls="300" renewal-period="60" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" />
-                <rate-limit-by-key calls="10"
-                   renewal-period="1"
-                   increment-condition="@(context.Response.StatusCode != 429)"
-                   counter-key="@(context.Subscription.Key)"/>
+                <rate-limit-by-key calls="600" renewal-period="60" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" remaining-calls-header-name="x-remaining-calls-per-min" />
+                <rate-limit-by-key calls="50" renewal-period="1" counter-key="@(context.Subscription.Key)" increment-condition="@(context.Response.StatusCode != 429)" remaining-calls-header-name="x-remaining-calls-per-sec" />
             </when>
         </choose>
     </inbound>


### PR DESCRIPTION
#### List of Changes
 - Incremented rate-limit per minute from 300 to 600 in `add-payments` and `delete-payments`
 - Incremented rate-limit per second from 10 to 50 in `add-payments` and `delete-payments`
 - Added headers `x-remaining-calls-per-sec` and `x-remaining-calls-per-min` for tracking purposes

#### Motivation and Context
During the initial stages of providing FdR3 services for PSPs, some partners complained about an excessive number of HTTP code 429 errors, caused by reaching the rate limit on `add-payments` and `delete-payments` API calls. This resulted in failure to meet the SLAs agreed with partners, who blocked the mass migration of FdRs for CIs to the new management system.  
The new limits allow for greater freedom in creating flows, reducing the number of 429 errors and allowing flows to be published in less time.

#### How Has This Been Tested?
 - Tested in UAT environment

#### Screenshots (if appropriate):

**_At first calls in the minute_**
<img width="1002" height="462" alt="image" src="https://github.com/user-attachments/assets/ce4ed99a-2422-463c-bd21-fc1a25ba946c" />

**_After 10 calls in the same minute_**
<img width="1364" height="543" alt="image" src="https://github.com/user-attachments/assets/ae89c237-086f-4b7d-b801-1e0984ce5442" />


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
