### PR TITLE
breaking: [PAGOPA-3487] Preparing ‘payments’ table for staging partitioning

### DIFF
--- a/.github/workflows/09_db_migration_with_github_runner.yml
+++ b/.github/workflows/09_db_migration_with_github_runner.yml
@@ -113,12 +113,12 @@ jobs:
           echo "
           classpath: ./src/main/resources/db/migration/liquibase/changelog
           liquibase.headless: true
-          url: jdbc:postgresql://${{ vars.POSTGRES_DB_HOST }}:${{ vars.POSTGRES_DB_PORT }}/postgres?prepareThreshold=0&currentSchema=cron
+          url: jdbc:postgresql://${{ vars.POSTGRES_DB_HOST }}:${{ vars.POSTGRES_DB_PORT }}/postgres?prepareThreshold=0
           contexts: ${{ inputs.environment }}
           username: ${{ vars.POSTGRES_DB_ADMIN_USERNAME }}
           password: ${{ secrets.POSTGRES_DB_ADMIN_PASSWORD }}
-          defaultSchemaName: cron
-          liquibaseSchemaName: cron
+          defaultSchemaName: public
+          liquibaseSchemaName: public
           liquibase.hub.mode: OFF
           log-level: INFO
           " > fdr.properties

--- a/.github/workflows/09_db_migration_with_github_runner.yml
+++ b/.github/workflows/09_db_migration_with_github_runner.yml
@@ -111,7 +111,7 @@ jobs:
           export PATH="$PATH:./liquibase-app"
 
           echo "
-          classpath: ./src/main/resources/db/migration/liquibase/changelog
+          classpath: ./src/main/resources/db/migration/liquibase/admin-changelog
           liquibase.headless: true
           url: jdbc:postgresql://${{ vars.POSTGRES_DB_HOST }}:${{ vars.POSTGRES_DB_PORT }}/postgres?prepareThreshold=0
           contexts: ${{ inputs.environment }}

--- a/.github/workflows/09_db_migration_with_github_runner.yml
+++ b/.github/workflows/09_db_migration_with_github_runner.yml
@@ -18,6 +18,14 @@ on:
           - dev
           - uat
           - prod
+      user:
+        required: true
+        type: choice
+        description: Select the user
+        options:
+          - fdr3
+          - admin
+        default: "fdr3"
       db_version:
         required: true
         description: Db version (👀 src/main/resources/db/migration/liquibase )
@@ -69,7 +77,8 @@ jobs:
           rm -rf liquibase-4.17.1.tar.gz
           ls -la liquibase-app
 
-      - name: Run liquibase::migrate
+      - name: Run liquibase::migrate [${{ vars.POSTGRES_DB_USERNAME }} user]
+        if: ${{ inputs.user == 'fdr3' }}
         shell: bash
         run: |
           export PATH="$PATH:./liquibase-app"
@@ -94,6 +103,29 @@ jobs:
           liquibase --defaultsFile=fdr.properties update --changelogFile="db.changelog-master-${{ inputs.db_version }}.xml"
 
           rm fdr.properties
+
+      - name: Run liquibase::migrate [${{ vars.POSTGRES_DB_ADMIN_USERNAME }} user]
+        if: ${{ inputs.user == 'admin' }}
+        shell: bash
+        run: |
+          export PATH="$PATH:./liquibase-app"
+
+          echo "
+          classpath: ./src/main/resources/db/migration/liquibase/changelog
+          liquibase.headless: true
+          url: jdbc:postgresql://${{ vars.POSTGRES_DB_HOST }}:${{ vars.POSTGRES_DB_PORT }}/postgres?prepareThreshold=0&currentSchema=cron
+          contexts: ${{ inputs.environment }}
+          username: ${{ vars.POSTGRES_DB_ADMIN_USERNAME }}
+          password: ${{ secrets.POSTGRES_DB_ADMIN_PASSWORD }}
+          defaultSchemaName: cron
+          liquibaseSchemaName: cron
+          liquibase.hub.mode: OFF
+          log-level: INFO
+          " > fdr.properties
+
+          liquibase --defaultsFile=fdr.properties update --changelogFile="db.changelog-master-${{ inputs.db_version }}.xml"
+
+          rm fdr.properties      
 
   cleanup_runner:
     name: Cleanup Runner

--- a/.github/workflows/09_db_migration_with_github_runner.yml
+++ b/.github/workflows/09_db_migration_with_github_runner.yml
@@ -113,12 +113,12 @@ jobs:
           echo "
           classpath: ./src/main/resources/db/migration/liquibase/admin-changelog
           liquibase.headless: true
-          url: jdbc:postgresql://${{ vars.POSTGRES_DB_HOST }}:${{ vars.POSTGRES_DB_PORT }}/postgres?prepareThreshold=0
+          url: jdbc:postgresql://${{ vars.POSTGRES_DB_HOST }}:${{ vars.POSTGRES_DB_PORT }}/fdr3?prepareThreshold=0
           contexts: ${{ inputs.environment }}
           username: ${{ vars.POSTGRES_DB_ADMIN_USERNAME }}
           password: ${{ secrets.POSTGRES_DB_ADMIN_PASSWORD }}
-          defaultSchemaName: public
-          liquibaseSchemaName: public
+          defaultSchemaName: ${{ vars.POSTGRES_DB_SCHEMA }}
+          liquibaseSchemaName: ${{ vars.POSTGRES_DB_SCHEMA }}
           liquibase.hub.mode: OFF
           log-level: INFO
           " > fdr.properties

--- a/.github/workflows/09_db_migration_with_github_runner.yml
+++ b/.github/workflows/09_db_migration_with_github_runner.yml
@@ -113,12 +113,12 @@ jobs:
           echo "
           classpath: ./src/main/resources/db/migration/liquibase/admin-changelog
           liquibase.headless: true
-          url: jdbc:postgresql://${{ vars.POSTGRES_DB_HOST }}:${{ vars.POSTGRES_DB_PORT }}/fdr3?prepareThreshold=0
+          url: jdbc:postgresql://${{ vars.POSTGRES_DB_HOST }}:${{ vars.POSTGRES_DB_PORT }}/postgres?prepareThreshold=0
           contexts: ${{ inputs.environment }}
           username: ${{ vars.POSTGRES_DB_ADMIN_USERNAME }}
           password: ${{ secrets.POSTGRES_DB_ADMIN_PASSWORD }}
-          defaultSchemaName: ${{ vars.POSTGRES_DB_SCHEMA }}
-          liquibaseSchemaName: ${{ vars.POSTGRES_DB_SCHEMA }}
+          defaultSchemaName: public
+          liquibaseSchemaName: public
           liquibase.hub.mode: OFF
           log-level: INFO
           " > fdr.properties

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -3,6 +3,7 @@
 -- ## SEQUENCES ##
 --changeset liquibase:admin-202603030000-01
 GRANT USAGE ON SCHEMA cron TO fdr3;
---changeset liquibase:admin-202603030000-02
+--changeset liquibase:admin-202603030000-02 endDelimiter:GO
 -- cron.schedule_in_database(job_name, schedule, command, database, username, active)
 SELECT cron.schedule_in_database('job_move_published_payments', '/10 * * * *', $$call fdr3.move_published_payments();$$,'fdr3', 'fdr3', true);
+GO

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -5,11 +5,13 @@
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 
 --changeset liquibase:admin-202603030000-02
-GRANT USAGE ON SCHEMA cron TO azureuser;
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA cron TO azureuser;
-GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA cron TO azureuser;
+-- GRANT USAGE ON SCHEMA cron TO azureuser;
+-- GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA cron TO azureuser;
+-- GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA cron TO azureuser;
+GRANT azure_pg_admin TO cron;
 
 --changeset liquibase:admin-202603030000-03 endDelimiter:GO
 -- cron.schedule(job_name, schedule, command, database, username, active)
-SELECT cron.schedule('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$);
+-- SELECT cron.schedule('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$);
+SELECT cron.schedule_in_database('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$,'fdr3');
 GO

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -2,8 +2,14 @@
 
 -- ## SEQUENCES ##
 --changeset liquibase:admin-202603030000-01
-GRANT USAGE ON SCHEMA cron TO fdr3;
---changeset liquibase:admin-202603030000-02 endDelimiter:GO
--- cron.schedule_in_database(job_name, schedule, command, database, username, active)
-SELECT cron.schedule_in_database('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$,'fdr3', 'azureuser', true);
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+--changeset liquibase:admin-202603030000-02
+GRANT USAGE ON SCHEMA cron TO azureuser;
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA cron TO azureuser;
+GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA cron TO azureuser;
+
+--changeset liquibase:admin-202603030000-03 endDelimiter:GO
+-- cron.schedule(job_name, schedule, command, database, username, active)
+SELECT cron.schedule('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$);
 GO

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -5,7 +5,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 
 --changeset liquibase:admin-202603030000-02 endDelimiter:GO
--- cron.schedule(job_name, schedule, command, database, username, active)
--- SELECT cron.schedule('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$);
+-- cron.schedule_in_database(job_name, schedule, command, database, username, active)
 SELECT cron.schedule_in_database('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$,'fdr3');
 GO

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -1,6 +1,8 @@
 --liquibase formatted sql
 
 -- ## SEQUENCES ##
---changeset liquibase:202603030000-01
+--changeset liquibase:admin-202603030000-01
+GRANT USAGE ON SCHEMA cron TO fdr3;
+--changeset liquibase:admin-202603030000-02
 -- cron.schedule_in_database(job_name, schedule, command, database, username, active)
-SELECT cron.schedule_in_database('job_move_published_payments', '/01 * * * *', $$call fdr3.move_published_payments();$$,'fdr3', 'fdr3', true);
+SELECT cron.schedule_in_database('job_move_published_payments', '/10 * * * *', $$call fdr3.move_published_payments();$$,'fdr3', 'fdr3', true);

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -4,13 +4,7 @@
 --changeset liquibase:admin-202603030000-01
 CREATE EXTENSION IF NOT EXISTS pg_cron;
 
---changeset liquibase:admin-202603030000-02
--- GRANT USAGE ON SCHEMA cron TO azureuser;
--- GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA cron TO azureuser;
--- GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA cron TO azureuser;
-GRANT azure_pg_admin TO cron;
-
---changeset liquibase:admin-202603030000-03 endDelimiter:GO
+--changeset liquibase:admin-202603030000-02 endDelimiter:GO
 -- cron.schedule(job_name, schedule, command, database, username, active)
 -- SELECT cron.schedule('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$);
 SELECT cron.schedule_in_database('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$,'fdr3');

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+
+-- ## SEQUENCES ##
+--changeset liquibase:202603030000-01
+-- cron.schedule_in_database(job_name, schedule, command, database, username, active)
+SELECT cron.schedule_in_database('job_move_published_payments', '/01 * * * *', $$call fdr3.move_published_payments();$$,'fdr3', 'fdr3', true);

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -5,5 +5,5 @@
 GRANT USAGE ON SCHEMA cron TO fdr3;
 --changeset liquibase:admin-202603030000-02 endDelimiter:GO
 -- cron.schedule_in_database(job_name, schedule, command, database, username, active)
-SELECT cron.schedule_in_database('job_move_published_payments', '/10 * * * *', $$call fdr3.move_published_payments();$$,'fdr3', 'fdr3', true);
+SELECT cron.schedule_in_database('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$,'fdr3', 'fdr3', true);
 GO

--- a/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/1.0.0/db.changelog-202603030000.sql
@@ -5,5 +5,5 @@
 GRANT USAGE ON SCHEMA cron TO fdr3;
 --changeset liquibase:admin-202603030000-02 endDelimiter:GO
 -- cron.schedule_in_database(job_name, schedule, command, database, username, active)
-SELECT cron.schedule_in_database('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$,'fdr3', 'fdr3', true);
+SELECT cron.schedule_in_database('job_move_published_payments', '*/10 * * * *', $$call fdr3.move_published_payments(10);$$,'fdr3', 'azureuser', true);
 GO

--- a/src/main/resources/db/migration/liquibase/admin-changelog/db.changelog-master-1.0.0.xml
+++ b/src/main/resources/db/migration/liquibase/admin-changelog/db.changelog-master-1.0.0.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+  http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+	<include file="./1.0.0/db.changelog-202603030000.sql" labels="init"/>
+
+</databaseChangeLog> 

--- a/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
@@ -43,7 +43,7 @@ END $$;
 GO
 
 --changeset liquibase:202602200004-02
-CREATE OR REPLACE VIEW IF NOT EXISTS fdr3.payment_full_view AS
+CREATE OR REPLACE VIEW fdr3.payment_full_view AS
     -- 1. extract data from payment
     SELECT
         flow_id,

--- a/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
@@ -81,6 +81,8 @@ CREATE OR REPLACE PROCEDURE fdr3.move_published_payments(
     p_lookback_minutes integer DEFAULT 1
 )
 LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = fdr3, pg_temp
 AS $$
     DECLARE
         v_start_date timestamp;
@@ -118,7 +120,7 @@ AS $$
     RAISE NOTICE 'Move completed: % payments moved to payment table in range between % and %', rows_moved, v_start_date, v_end_date;
     EXCEPTION
         WHEN OTHERS THEN
-            RAISE EXCEPTION 'Error during moving items: %', SQLERRM;
+            RAISE WARNING 'Error during moving items: %', SQLERRM;
     END;
 $$;
 GO

--- a/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
@@ -83,6 +83,8 @@ CREATE OR REPLACE PROCEDURE fdr3.move_published_payments(
 LANGUAGE plpgsql
 AS $$
     DECLARE
+        v_start_date timestamp;
+        v_end_date timestamp;
         rows_moved integer;
     BEGIN
     v_end_date := date_trunc('minute', now());

--- a/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
@@ -77,7 +77,7 @@ UNION ALL
     FROM fdr3.payment_staging;
 
 --changeset liquibase:202602200004-03 endDelimiter:GO
-CREATE OR REPLACE PROCEDURE IF NOT EXISTS fdr3.move_published_payments(
+CREATE OR REPLACE PROCEDURE fdr3.move_published_payments(
     p_start_date timestamp,
     p_end_date timestamp
 )

--- a/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
@@ -78,40 +78,42 @@ UNION ALL
 
 --changeset liquibase:202602200004-03 endDelimiter:GO
 CREATE OR REPLACE PROCEDURE fdr3.move_published_payments(
-    p_start_date timestamp,
-    p_end_date timestamp
+    p_lookback_minutes integer DEFAULT 1
 )
 LANGUAGE plpgsql
 AS $$
     DECLARE
         rows_moved integer;
     BEGIN
+    v_end_date := date_trunc('minute', now());
+    v_start_date := v_end_date - (p_lookback_minutes * interval '1 minute');
+    RAISE NOTICE 'Move start: moving payments in range between % and %', v_start_date, v_end_date;
     -- use CTE to identify, delete and insert in one shot
     WITH
         target_flows AS (
             -- identify flow ids published in a specified temporal range
             SELECT id FROM fdr3.flow
             WHERE status = 'PUBLISHED'
-                AND published >= p_start_date
-                AND published <= p_end_date
+                AND published >= v_start_date
+                AND published < v_end_date
         ),
         deleted_rows AS (
             -- delete from payment_staging rows belonging to published flows
             DELETE FROM fdr3.payment_staging
                 WHERE flow_id IN (SELECT id FROM target_flows)
             RETURNING
-                flow_id, iuv, iur, index, amount,
+                flow_id, iuv, iur, "index", amount,
                 pay_date, pay_status, transfer_id, created, updated
         )
     -- insert row in the payment table
     INSERT INTO fdr3.payment (
-        flow_id, iuv, iur, index, amount,
+        flow_id, iuv, iur, "index", amount,
         pay_date, pay_status, transfer_id, created, updated
     )
     SELECT * FROM deleted_rows;
 
     GET DIAGNOSTICS rows_moved = ROW_COUNT;
-    RAISE NOTICE 'Move completed: % payments moved to payment table in range between % and %', rows_moved, p_start_date, p_end_date;
+    RAISE NOTICE 'Move completed: % payments moved to payment table in range between % and %', rows_moved, v_start_date, v_end_date;
     EXCEPTION
         WHEN OTHERS THEN
             RAISE EXCEPTION 'Error during moving items: %', SQLERRM;

--- a/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
@@ -1,7 +1,7 @@
 --liquibase formatted sql
 
 -- ## TABLE PAYMENT_STAGING ##
---changeset liquibase:202602200004-01
+--changeset liquibase:202602200004-01 endDelimiter:GO
 DO $$
 DECLARE
     schema_name TEXT := 'fdr3';
@@ -40,7 +40,7 @@ EXECUTE format('
                schema_name, partition_name, schema_name, table_name, modulus_val, i);
 END LOOP;
 END $$;
-
+GO
 
 --changeset liquibase:202602200004-02
 CREATE OR REPLACE VIEW IF NOT EXISTS fdr3.payment_full_view AS
@@ -76,7 +76,7 @@ UNION ALL
         'STAGING'::text AS record_origin
     FROM fdr3.payment_staging;
 
---changeset liquibase:202602200004-03
+--changeset liquibase:202602200004-03 endDelimiter:GO
 CREATE OR REPLACE PROCEDURE IF NOT EXISTS fdr3.move_published_payments(
     p_start_date timestamp,
     p_end_date timestamp
@@ -117,3 +117,4 @@ AS $$
             RAISE EXCEPTION 'Error during moving items: %', SQLERRM;
     END;
 $$;
+GO

--- a/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
@@ -124,3 +124,5 @@ AS $$
     END;
 $$;
 GO
+
+GRANT EXECUTE ON PROCEDURE fdr3.move_published_payments(integer) TO azureuser;

--- a/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
+++ b/src/main/resources/db/migration/liquibase/changelog/1.1.0/db.changelog-202602200004.sql
@@ -1,0 +1,119 @@
+--liquibase formatted sql
+
+-- ## TABLE PAYMENT_STAGING ##
+--changeset liquibase:202602200004-01
+DO $$
+DECLARE
+    schema_name TEXT := 'fdr3';
+    table_name TEXT := 'payment_staging';
+    modulus_val INTEGER := 32;
+    i INTEGER;
+    partition_name TEXT;
+BEGIN
+    -- 1. Create master table
+EXECUTE format('
+        CREATE TABLE IF NOT EXISTS %I.%I (
+            flow_id bigint NOT NULL,
+            index bigint NOT NULL,
+            org_id character varying(15) NOT NULL,
+            iuv character varying(35) NOT NULL,
+            iur character varying(35) NOT NULL,
+            amount numeric(19,2) NOT NULL,
+            pay_date timestamp(6) NOT NULL,
+            pay_status character varying(50) NOT NULL,
+            transfer_id bigint NOT NULL,
+            created timestamp(6),
+            updated timestamp(6),
+            CONSTRAINT payment_pk PRIMARY KEY (flow_id, index, org_id)
+        ) PARTITION BY HASH (org_id);',
+               schema_name, table_name);
+
+-- 2. Create partitions
+FOR i IN 0..(modulus_val - 1) LOOP
+        -- format naming as payment_staging_p01, payment_staging_p02...
+        partition_name := format('%s_p%s', table_name, lpad(i::text, 2, '0'));
+
+EXECUTE format('
+            CREATE TABLE IF NOT EXISTS %I.%I
+            PARTITION OF %I.%I
+            FOR VALUES WITH (MODULUS %s, REMAINDER %s);',
+               schema_name, partition_name, schema_name, table_name, modulus_val, i);
+END LOOP;
+END $$;
+
+
+--changeset liquibase:202602200004-02
+CREATE OR REPLACE VIEW IF NOT EXISTS fdr3.payment_full_view AS
+    -- 1. extract data from payment
+    SELECT
+        flow_id,
+        index,
+        iuv,
+        iur,
+        amount,
+        pay_date,
+        pay_status,
+        transfer_id,
+        created,
+        updated,
+        'FINAL'::text AS record_origin
+    FROM fdr3.payment
+
+UNION ALL
+
+    -- 2. extract data from payment_staging
+    SELECT
+        flow_id,
+        index,
+        iuv,
+        iur,
+        amount,
+        pay_date,
+        pay_status,
+        transfer_id,
+        created,
+        updated,
+        'STAGING'::text AS record_origin
+    FROM fdr3.payment_staging;
+
+--changeset liquibase:202602200004-03
+CREATE OR REPLACE PROCEDURE IF NOT EXISTS fdr3.move_published_payments(
+    p_start_date timestamp,
+    p_end_date timestamp
+)
+LANGUAGE plpgsql
+AS $$
+    DECLARE
+        rows_moved integer;
+    BEGIN
+    -- use CTE to identify, delete and insert in one shot
+    WITH
+        target_flows AS (
+            -- identify flow ids published in a specified temporal range
+            SELECT id FROM fdr3.flow
+            WHERE status = 'PUBLISHED'
+                AND published >= p_start_date
+                AND published <= p_end_date
+        ),
+        deleted_rows AS (
+            -- delete from payment_staging rows belonging to published flows
+            DELETE FROM fdr3.payment_staging
+                WHERE flow_id IN (SELECT id FROM target_flows)
+            RETURNING
+                flow_id, iuv, iur, index, amount,
+                pay_date, pay_status, transfer_id, created, updated
+        )
+    -- insert row in the payment table
+    INSERT INTO fdr3.payment (
+        flow_id, iuv, iur, index, amount,
+        pay_date, pay_status, transfer_id, created, updated
+    )
+    SELECT * FROM deleted_rows;
+
+    GET DIAGNOSTICS rows_moved = ROW_COUNT;
+    RAISE NOTICE 'Move completed: % payments moved to payment table in range between % and %', rows_moved, p_start_date, p_end_date;
+    EXCEPTION
+        WHEN OTHERS THEN
+            RAISE EXCEPTION 'Error during moving items: %', SQLERRM;
+    END;
+$$;

--- a/src/main/resources/db/migration/liquibase/changelog/db.changelog-master-1.1.0.xml
+++ b/src/main/resources/db/migration/liquibase/changelog/db.changelog-master-1.1.0.xml
@@ -10,5 +10,6 @@
   <include file="./${version}/db.changelog-202602200001.sql" labels="${version}"/>
   <include file="./${version}/db.changelog-202602200002.sql" labels="${version}"/>
   <include file="./${version}/db.changelog-202602200003.sql" labels="${version}"/>
+  <include file="./${version}/db.changelog-202602200004.sql" labels="${version}"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
#### List of Changes
 - Defining strategy for move staging payments to stable table
 - Including `pg_cron` extension on PostgreSQL database
 - Fixing DB migration pipeline workflow, including operations on non-`fdr3` schema

#### Motivation and Context
This PR includes some infrastructure changes to the `fdr3` database in order to improve performance when adding payments by including a payment data staging strategy. The changes follow the guidelines outlined in the analysis of the `payment` table partition,  described [on this page](https://pagopa.atlassian.net/wiki/spaces/IQCGJ/pages/2687500311/Analisi+-+Partizionamento+tabella+payment).

#### How Has This Been Tested?
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
