### PR TITLE
fix: [PIDM-1660] Add offsets ignore instruction on payment date time

### DIFF
--- a/src/main/java/it/gov/pagopa/fdr/controller/model/payment/Payment.java
+++ b/src/main/java/it/gov/pagopa/fdr/controller/model/payment/Payment.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import it.gov.pagopa.fdr.controller.middleware.serialization.MonetarySerializer;
 import it.gov.pagopa.fdr.controller.model.payment.enums.PaymentStatusEnum;
-import it.gov.pagopa.fdr.util.common.IgnoreOffsetInstantDeserializer;
 import it.gov.pagopa.fdr.util.serialization.InstantWithoutOffsetDeserializer;
 import jakarta.validation.constraints.*;
 import java.time.Instant;

--- a/src/main/java/it/gov/pagopa/fdr/controller/model/payment/Payment.java
+++ b/src/main/java/it/gov/pagopa/fdr/controller/model/payment/Payment.java
@@ -1,8 +1,11 @@
 package it.gov.pagopa.fdr.controller.model.payment;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import it.gov.pagopa.fdr.controller.middleware.serialization.MonetarySerializer;
 import it.gov.pagopa.fdr.controller.model.payment.enums.PaymentStatusEnum;
+import it.gov.pagopa.fdr.util.common.IgnoreOffsetInstantDeserializer;
+import it.gov.pagopa.fdr.util.serialization.InstantWithoutOffsetDeserializer;
 import jakarta.validation.constraints.*;
 import java.time.Instant;
 import lombok.Builder;
@@ -78,6 +81,7 @@ public class Payment {
               + " 8</li><li>NO_RPT -> 9</li></ul>")
   private PaymentStatusEnum payStatus;
 
+  @JsonDeserialize(using = InstantWithoutOffsetDeserializer.class)
   @NotNull
   @Schema(
       example = "2025-01-01T12:30:50.900000Z",

--- a/src/main/java/it/gov/pagopa/fdr/util/serialization/InstantWithoutOffsetDeserializer.java
+++ b/src/main/java/it/gov/pagopa/fdr/util/serialization/InstantWithoutOffsetDeserializer.java
@@ -1,0 +1,29 @@
+package it.gov.pagopa.fdr.util.serialization;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.*;
+import java.time.format.DateTimeParseException;
+
+public class InstantWithoutOffsetDeserializer extends JsonDeserializer<Instant> {
+
+  @Override
+  public Instant deserialize(JsonParser parser, DeserializationContext context) throws IOException {
+
+    String value = parser.getText();
+    LocalDateTime localDateTime;
+    try {
+      localDateTime = OffsetDateTime.parse(value).toLocalDateTime();
+    } catch (DateTimeParseException e) {
+      try {
+        localDateTime = LocalDateTime.parse(value);
+      } catch (DateTimeParseException e2) {
+        localDateTime = LocalDate.parse(value).atStartOfDay();
+      }
+    }
+    return localDateTime.toInstant(ZoneOffset.UTC);
+  }
+}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
 - Added `InstantWithoutOffsetDeserializer` class for deserialize `Instant` without timezones

#### Motivation and Context
To resolve an anomaly in the `payDate` field, a correction has been introduced for the deserialisation of the DTOs: the value is now interpreted by using only the date and time received from the PSP, ignoring any time zone offset present. The fix is designed to preserve the payment date-time using logic that prioritises the business date and time over the absolute time transmitted by the PSP.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
