### PR TITLE
fix: Refactoring schedulations for maintenance procedures

### DIFF
--- a/src/main/resources/db/migration/liquibase/archive/azureuser.changelog/1.0.2/db.changelog-202603100001.sql
+++ b/src/main/resources/db/migration/liquibase/archive/azureuser.changelog/1.0.2/db.changelog-202603100001.sql
@@ -11,12 +11,12 @@
 -- cron.schedule_in_database(job_name, schedule, command, database, username, active)
 SELECT cron.schedule_in_database
        ('job_create_partition_on_month'
-        ,'0 0 1 * *'
+        ,'0 0 25 * *'
         ,$$CALL maintenance.create_partition_on_month();$$
         ,'fdr3');
 SELECT cron.schedule_in_database
        ('job_delete_expired_partitions'
-        ,'0 0 1 * *'
+        ,'0 4 1 * *'
         ,$$CALL maintenance.delete_expired_partitions();$$
         ,'fdr3');
 SELECT cron.schedule_in_database


### PR DESCRIPTION
#### List of Changes
 - Changed schedule for `create_partition_on_month` procedure, passing from 1st day of the current month to 25th day of the current month
 - Changed schedule for `delete_expired_partitions` procedure, passing from 1st day of the current month at 00:00 to 1st day of the current month at 04:00

#### Motivation and Context
This PR aims to resolve a configuration error relating to the scheduling of procedures for maintenance processes. Specifically, the `create_partition_on_month` procedure had not been running correctly for several months because it was being triggered at 00:00 in the UTC timezone rather than the Rome timezone. This prevented the partition from being created correctly.

#### How Has This Been Tested?
Tested in DEV and UAT environments

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
  expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
